### PR TITLE
Fix TypeScript errors in LandingPage and BaseLayout

### DIFF
--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, FormEvent } from "react";
+import { useState, type FormEvent } from "react";
 import { useReveal } from "~/hooks/use-reveal";
 import itemWatch from "~/assets/item-watch.jpg";
 import itemCamera from "~/assets/item-camera.jpg";

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -37,7 +37,7 @@ import '~/assets/styles/tailwind.css';
         inView(
           el,
           () => {
-            animate(el, { opacity: 1, transform: 'translateY(0px)' }, { duration: 0.7, easing: [0.25, 0.1, 0.25, 1] });
+            animate(el as HTMLElement, { opacity: 1, transform: 'translateY(0px)' }, { duration: 0.7, easing: [0.25, 0.1, 0.25, 1] });
           },
           { margin: '-10% 0px' }
         );


### PR DESCRIPTION
Issue #1 の修正

- FormEvent を型専用インポート (type FormEvent) に変更
- 未使用の useEffect インポートを削除
- BaseLayout の animate 呼び出しで el を HTMLElement にキャスト

Closes #1

Generated with [Claude Code](https://claude.ai/code)