### PR TITLE
fix: HTML 圧縮の空白削除で React ハイドレーション (#418) を防ぐ

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -58,6 +58,8 @@ export default defineConfig({
       HTML: {
         'html-minifier-terser': {
           removeAttributeQuotes: false,
+          // React SSR のインライン間空白を削るとハイドレーション (#418) が起きる
+          collapseWhitespace: false,
         },
       },
       Image: false,


### PR DESCRIPTION
astro-compress の html-minifier-terser が collapseWhitespace を有効にしており、 SSR 済みの React 島のインライン要素間のテキスト空白が消えて DOM と不一致になる。
collapseWhitespace: false で本番ビルド後のハイドレーションを安定させる。