### PR TITLE
SEO対策：タイトル・メタディスクリプション更新、キャンペーン表記修正

### DIFF
--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -366,7 +366,9 @@ const CompetitiveTable = () => {
                   >
                     {label === '決済手数料' ? (
                       <span className="inline-flex flex-col items-center gap-1">
-                        <span className="text-text-primary" style={{ fontSize: 13 }}>{r}</span>
+                        <span className="text-text-primary" style={{ fontSize: 13 }}>
+                          {r}
+                        </span>
                         <span
                           className="font-sans-ui text-gold-light bg-gold-muted"
                           style={{ fontSize: 9, letterSpacing: '0.15em', padding: '2px 6px' }}

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -159,7 +159,7 @@ const Hero = ({ onCtaClick }: { onCtaClick: (e?: React.MouseEvent) => void }) =>
       </div>
 
       <p className="mt-4 text-text-secondary" style={{ fontSize: 11 }}>
-        メールアドレスだけで完了 · リリース時に真っ先にご連絡します · 先着順で初期費用3ヶ月無料
+        メールアドレスだけで完了 · リリース時に真っ先にご連絡します · 先着順で初期費用と3ヶ月の決済手数料無料
       </p>
     </div>
   </section>
@@ -364,7 +364,17 @@ const CompetitiveTable = () => {
                       borderRight: '1px solid hsl(var(--gold-deep))',
                     }}
                   >
-                    {label === '月額費用' ? (
+                    {label === '決済手数料' ? (
+                      <span className="inline-flex flex-col items-center gap-1">
+                        <span className="text-text-primary" style={{ fontSize: 13 }}>{r}</span>
+                        <span
+                          className="font-sans-ui text-gold-light bg-gold-muted"
+                          style={{ fontSize: 9, letterSpacing: '0.15em', padding: '2px 6px' }}
+                        >
+                          キャンペーン中
+                        </span>
+                      </span>
+                    ) : label === '月額費用' ? (
                       <span className="inline-flex flex-col items-center gap-1">
                         <span className="inline-flex items-baseline gap-2">
                           <span className="text-text-secondary line-through opacity-50" style={{ fontSize: 13 }}>
@@ -558,18 +568,18 @@ const RegisterForm = () => {
           style={{ fontSize: 'clamp(32px, 5vw, 44px)', lineHeight: 1.2 }}
           data-reveal-delay="0.05s"
         >
-          今登録すると、初期費用が{' '}
+          今登録すると、初期費用と{' '}
           <span className="text-gold-deep">
-            <span className="num-cjk">3</span>ヶ月無料
+            <span className="num-cjk">3</span>ヶ月の決済手数料
           </span>{' '}
-          になります。
+          が無料になります。
         </h2>
         <p
           className="reveal mt-8 text-text-secondary text-left"
           style={{ fontSize: 13, lineHeight: 1.9 }}
           data-reveal-delay="0.1s"
         >
-          RentRichは現在、正式リリースに向けて準備中です。家電・時計・ブランド品・家具・おもちゃなど、あらゆる商材のレンタルEC開設に対応します。ご登録いただくと、リリース時に真っ先にお知らせします。登録いただいた方には、初期費用3ヶ月分を無料でご提供します(先着順)。
+          RentRichは現在、正式リリースに向けて準備中です。家電・時計・ブランド品・家具・おもちゃなど、あらゆる商材のレンタルEC開設に対応します。ご登録いただくと、リリース時に真っ先にお知らせします。登録いただいた方には、初期費用と3ヶ月の決済手数料を無料でご提供します(先着順)。
         </p>
 
         <form onSubmit={onSubmit} className="reveal mt-10 flex flex-col gap-3 text-left" data-reveal-delay="0.15s">

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -8,7 +8,10 @@ import '~/assets/styles/tailwind.css';
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>レンタルECプラットフォーム | 最短1日で開設・初期費用無料 | RentRich</title>
-    <meta name="description" content="レンタル事業を最短1日で始められるECプラットフォーム。初期費用・月額固定費不要で導入でき、盗難・紛失対策のデポジット保護機能を標準搭載。家電・時計・家具など商材を問わず対応。先行登録で初期費用と3ヶ月分の手数料無料。" />
+    <meta
+      name="description"
+      content="レンタル事業を最短1日で始められるECプラットフォーム。初期費用・月額固定費不要で導入でき、盗難・紛失対策のデポジット保護機能を標準搭載。家電・時計・家具など商材を問わず対応。先行登録で初期費用と3ヶ月分の手数料無料。"
+    />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -7,17 +7,18 @@ import '~/assets/styles/tailwind.css';
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>RentRich — あなたのショップを、レンタルECへ。</title>
+    <title>レンタルECプラットフォーム | 最短1日で開設・初期費用無料 | RentRich</title>
+    <meta name="description" content="レンタル事業を最短1日で始められるECプラットフォーム。初期費用・月額固定費不要で導入でき、盗難・紛失対策のデポジット保護機能を標準搭載。家電・時計・家具など商材を問わず対応。先行登録で初期費用と3ヶ月分の手数料無料。" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
       href="https://fonts.googleapis.com/css2?family=Shippori+Mincho+B1:wght@500&family=Cormorant+Garamond:wght@400;600&family=IBM+Plex+Mono:wght@400;500&family=Inter:wght@400;500&display=swap"
       rel="stylesheet"
     />
-    <meta property="og:title" content="RentRich — あなたのショップを、レンタルECへ。" />
+    <meta property="og:title" content="レンタルECプラットフォーム | 最短1日で開設・初期費用無料 | RentRich" />
     <meta
       property="og:description"
-      content="ファッションブランドがかんたんにレンタルECを開設できるプラットフォーム。先行登録で初期費用3ヶ月無料。"
+      content="レンタル事業を最短1日で始められるECプラットフォーム。初期費用・月額固定費不要で導入でき、盗難・紛失対策のデポジット保護機能を標準搭載。家電・時計・家具など商材を問わず対応。先行登録で初期費用と3ヶ月分の手数料無料。"
     />
     <meta property="og:type" content="website" />
     <meta property="og:locale" content="ja_JP" />


### PR DESCRIPTION
Fixes #8

## 変更内容

- ページタイトルをSEO最適化されたものに変更
- meta descriptionおよびog:descriptionを追加・更新
- 「初期費用3ヶ月分無料」→「初期費用と3ヶ月の決済手数料無料」に統一（3箇所）
- 競合テーブルの決済手数料（5%）に「キャンペーン中」バッジを追加

Generated with [Claude Code](https://claude.ai/code)